### PR TITLE
fix: prevent duplicate user registration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,3 +65,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Trigger Dokploy Deploy
+        run: |
+          curl -X POST "${{ secrets.DOKPLOY_WEBHOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            -d '{"service":"ktor-service"}'

--- a/composeApp/src/commonMain/kotlin/com/ghn/poker/tracker/data/api/GizmoApiClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/ghn/poker/tracker/data/api/GizmoApiClient.kt
@@ -30,7 +30,8 @@ import kotlinx.serialization.json.Json
 import org.koin.core.annotation.Single
 import io.ktor.client.plugins.logging.Logger as KtorLogger
 
-private const val BASE_URL = "138.197.84.104"
+// private const val BASE_URL = "138.197.84.104"
+private const val BASE_URL = "gizmo-gizmoservice-5hu6qr-a1aff5-95-217-220-208.traefik.me"
 // private const val BASE_URL = "10.0.2.2:8080"
 
 @Single([GizmoApiClient::class])

--- a/server/src/main/kotlin/com/ghn/repository/UserRepositoryImpl.kt
+++ b/server/src/main/kotlin/com/ghn/repository/UserRepositoryImpl.kt
@@ -34,6 +34,11 @@ class UserRepositoryImpl(
     }
 
     override fun create(user: User): ApiCallResult<Unit> {
+        val existingUser = db.fetchOne(USER, USER.USERNAME.eq(user.username))
+        if (existingUser != null) {
+            return ApiCallResult.AlreadyExists
+        }
+
         val newRecord = db.newRecord(USER)
         newRecord.from(user.toUserDTO())
         newRecord.store()
@@ -47,4 +52,5 @@ sealed interface ApiCallResult<out T> {
     data object BadPassword : ApiCallResult<Nothing>
     data object Unauthorized : ApiCallResult<Nothing>
     data object NotFound : ApiCallResult<Nothing>
+    data object AlreadyExists : ApiCallResult<Nothing>
 }

--- a/server/src/main/kotlin/com/ghn/service/RefreshTokenServiceImpl.kt
+++ b/server/src/main/kotlin/com/ghn/service/RefreshTokenServiceImpl.kt
@@ -31,6 +31,8 @@ class RefreshTokenServiceImpl(
             ApiCallResult.Unauthorized -> ApiCallResult.Unauthorized
 
             is ApiCallResult.Failure -> result
+
+            ApiCallResult.AlreadyExists -> ApiCallResult.Failure("Unexpected error")
         }
     }
 

--- a/server/src/main/resources/db/migration/V3__Add_unique_constraint_to_username.sql
+++ b/server/src/main/resources/db/migration/V3__Add_unique_constraint_to_username.sql
@@ -1,0 +1,2 @@
+-- Add unique constraint to username column in user table to prevent duplicate registrations
+CREATE UNIQUE INDEX idx_user_username ON user(username);


### PR DESCRIPTION
- Add UNIQUE constraint on username column
- Add duplicate user check in UserRepositoryImpl
- Return HTTP 409 Conflict for existing usernames
- Add ApiCallResult.AlreadyExists error type