### PR TITLE
 chore: update dependencies and re-enable Mokkery tests

### DIFF
--- a/feature/feature-auth/build.gradle.kts
+++ b/feature/feature-auth/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("gizmo.feature")
-//    alias(libs.plugins.mokkery)
+    alias(libs.plugins.mokkery)
 }
 
 android {
@@ -22,8 +22,8 @@ kotlin {
             implementation(project(":common"))
         }
         commonTest.dependencies {
-//            implementation(libs.mokkery.core)
-//            implementation(libs.mokkery.coroutines)
+            implementation(libs.mokkery.core)
+            implementation(libs.mokkery.coroutines)
         }
     }
 }

--- a/feature/feature-auth/src/commonTest/kotlin/com/ghn/poker/feature/auth/data/repository/LoginRepositoryImplTest.kt
+++ b/feature/feature-auth/src/commonTest/kotlin/com/ghn/poker/feature/auth/data/repository/LoginRepositoryImplTest.kt
@@ -1,9 +1,5 @@
-@file:Suppress("ktlint:standard:no-empty-file")
-
 package com.ghn.poker.feature.auth.data.repository
 
-// TODO: Re-enable once mokkery is updated for kotlin 2.3+ support
-/*
 import com.ghn.model.TokenResponse
 import com.ghn.poker.core.network.ApiResponse
 import com.ghn.poker.feature.auth.data.sources.remote.LoginRemoteDataSource
@@ -117,4 +113,3 @@ class LoginRepositoryImplTest {
         verifySuspend { remoteDataSource.logout() }
     }
 }
-*/

--- a/feature/feature-auth/src/commonTest/kotlin/com/ghn/poker/feature/auth/domain/usecase/impl/CreateAccountUseCaseImplTest.kt
+++ b/feature/feature-auth/src/commonTest/kotlin/com/ghn/poker/feature/auth/domain/usecase/impl/CreateAccountUseCaseImplTest.kt
@@ -1,9 +1,5 @@
-@file:Suppress("ktlint:standard:no-empty-file")
-
 package com.ghn.poker.feature.auth.domain.usecase.impl
 
-// TODO: Re-enable once mokkery is updated for kotlin 2.3+ support
-/*
 import com.ghn.poker.core.network.ApiResponse
 import com.ghn.poker.feature.auth.domain.repository.LoginRepository
 import dev.mokkery.MockMode
@@ -35,4 +31,3 @@ class CreateAccountUseCaseImplTest {
         verifySuspend(VerifyMode.exactly(1)) { loginRepository.create(username, password) }
     }
 }
-*/

--- a/feature/feature-auth/src/commonTest/kotlin/com/ghn/poker/feature/auth/domain/usecase/impl/LoginUseCaseImplTest.kt
+++ b/feature/feature-auth/src/commonTest/kotlin/com/ghn/poker/feature/auth/domain/usecase/impl/LoginUseCaseImplTest.kt
@@ -1,9 +1,5 @@
-@file:Suppress("ktlint:standard:no-empty-file")
-
 package com.ghn.poker.feature.auth.domain.usecase.impl
 
-// TODO: Re-enable once mokkery is updated for kotlin 2.3+ support
-/*
 import com.ghn.poker.core.network.ApiResponse
 import com.ghn.poker.feature.auth.domain.repository.LoginRepository
 import dev.mokkery.answering.returns
@@ -59,4 +55,3 @@ class LoginUseCaseImplTest {
         verifySuspend { loginRepository.login("user", "wrong") }
     }
 }
-*/

--- a/feature/feature-auth/src/commonTest/kotlin/com/ghn/poker/feature/auth/presentation/LoginViewModelTest.kt
+++ b/feature/feature-auth/src/commonTest/kotlin/com/ghn/poker/feature/auth/presentation/LoginViewModelTest.kt
@@ -1,9 +1,5 @@
-@file:Suppress("ktlint:standard:no-empty-file")
-
 package com.ghn.poker.feature.auth.presentation
 
-// TODO: Re-enable once mokkery is updated for kotlin 2.3+ support
-/*
 import com.ghn.poker.core.network.ApiResponse
 import com.ghn.poker.core.testing.BaseViewModelTest
 import com.ghn.poker.feature.auth.domain.usecase.LoginUseCase
@@ -143,4 +139,3 @@ class LoginViewModelTest : BaseViewModelTest() {
         viewModel.state.value.authenticating.shouldBeFalse()
     }
 }
-*/

--- a/feature/feature-cards/build.gradle.kts
+++ b/feature/feature-cards/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("gizmo.feature")
-//    alias(libs.plugins.mokkery)
+    alias(libs.plugins.mokkery)
 }
 
 android {
@@ -23,8 +23,8 @@ kotlin {
             implementation(libs.collections.immutable)
         }
         commonTest.dependencies {
-//            implementation(libs.mokkery.core)
-//            implementation(libs.mokkery.coroutines)
+            implementation(libs.mokkery.core)
+            implementation(libs.mokkery.coroutines)
         }
     }
 }

--- a/feature/feature-cards/src/commonTest/kotlin/com/ghn/poker/feature/cards/data/repository/HandEvaluatorRepositoryImplTest.kt
+++ b/feature/feature-cards/src/commonTest/kotlin/com/ghn/poker/feature/cards/data/repository/HandEvaluatorRepositoryImplTest.kt
@@ -1,9 +1,5 @@
-@file:Suppress("ktlint:standard:no-empty-file")
-
 package com.ghn.poker.feature.cards.data.repository
 
-// TODO: Re-enable once mokkery is updated for kotlin 2.3+ support
-/*
 import com.ghn.gizmodb.common.models.Card
 import com.ghn.gizmodb.common.models.CardSuit
 import com.ghn.gizmodb.common.models.EvaluatorResponse
@@ -155,4 +151,3 @@ class HandEvaluatorRepositoryImplTest {
         result shouldBe ApiResponse.Success(expectedResponse)
     }
 }
-*/

--- a/feature/feature-cards/src/commonTest/kotlin/com/ghn/poker/feature/cards/domain/usecase/impl/EquityCalculationUseCaseImplTest.kt
+++ b/feature/feature-cards/src/commonTest/kotlin/com/ghn/poker/feature/cards/domain/usecase/impl/EquityCalculationUseCaseImplTest.kt
@@ -1,9 +1,5 @@
-@file:Suppress("ktlint:standard:no-empty-file")
-
 package com.ghn.poker.feature.cards.domain.usecase.impl
 
-// TODO: Re-enable once mokkery is updated for kotlin 2.3+ support
-/*
 import com.ghn.gizmodb.common.models.Card
 import com.ghn.gizmodb.common.models.CardSuit
 import com.ghn.gizmodb.common.models.EvaluatorResponse
@@ -101,4 +97,3 @@ class EquityCalculationUseCaseImplTest {
         result shouldBe expected
     }
 }
-*/

--- a/feature/feature-cards/src/commonTest/kotlin/com/ghn/poker/feature/cards/presentation/EquityCalculatorViewModelTest.kt
+++ b/feature/feature-cards/src/commonTest/kotlin/com/ghn/poker/feature/cards/presentation/EquityCalculatorViewModelTest.kt
@@ -1,9 +1,5 @@
-@file:Suppress("ktlint:standard:no-empty-file")
-
 package com.ghn.poker.feature.cards.presentation
 
-// TODO: Re-enable once mokkery is updated for kotlin 2.3+ support
-/*
 import com.ghn.gizmodb.common.models.Card
 import com.ghn.gizmodb.common.models.CardSuit
 import com.ghn.gizmodb.common.models.EvaluatorResponse
@@ -253,4 +249,3 @@ class EquityCalculatorViewModelTest : BaseViewModelTest() {
         advanceUntilIdle()
     }
 }
-*/

--- a/feature/feature-feed/build.gradle.kts
+++ b/feature/feature-feed/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("gizmo.feature")
-//    alias(libs.plugins.mokkery)
+    alias(libs.plugins.mokkery)
 }
 
 android {
@@ -23,8 +23,8 @@ kotlin {
             api(libs.webview.multiplatform)
         }
         commonTest.dependencies {
-//            implementation(libs.mokkery.core)
-//            implementation(libs.mokkery.coroutines)
+            implementation(libs.mokkery.core)
+            implementation(libs.mokkery.coroutines)
         }
     }
 }

--- a/feature/feature-feed/src/commonTest/kotlin/com/ghn/poker/feature/feed/data/repository/FeedRepositoryImplTest.kt
+++ b/feature/feature-feed/src/commonTest/kotlin/com/ghn/poker/feature/feed/data/repository/FeedRepositoryImplTest.kt
@@ -1,9 +1,5 @@
-@file:Suppress("ktlint:standard:no-empty-file")
-
 package com.ghn.poker.feature.feed.data.repository
 
-// TODO: Re-enable once mokkery is updated for kotlin 2.3+ support
-/*
 import com.ghn.gizmodb.common.models.FeedDTO
 import com.ghn.gizmodb.common.models.NewsCategory
 import com.ghn.poker.core.network.ApiResponse
@@ -106,4 +102,3 @@ class FeedRepositoryImplTest {
         )
     }
 }
-*/

--- a/feature/feature-feed/src/commonTest/kotlin/com/ghn/poker/feature/feed/domain/usecase/impl/FeedUseCaseImplTest.kt
+++ b/feature/feature-feed/src/commonTest/kotlin/com/ghn/poker/feature/feed/domain/usecase/impl/FeedUseCaseImplTest.kt
@@ -1,9 +1,5 @@
-@file:Suppress("ktlint:standard:no-empty-file")
-
 package com.ghn.poker.feature.feed.domain.usecase.impl
 
-// TODO: Re-enable once mokkery is updated for kotlin 2.3+ support
-/*
 import com.ghn.gizmodb.common.models.FeedDTO
 import com.ghn.gizmodb.common.models.NewsCategory
 import com.ghn.poker.core.network.ApiResponse
@@ -92,4 +88,3 @@ class FeedUseCaseImplTest {
         verifySuspend { repository.getFeed() }
     }
 }
-*/

--- a/feature/feature-feed/src/commonTest/kotlin/com/ghn/poker/feature/feed/presentation/FeedViewModelTest.kt
+++ b/feature/feature-feed/src/commonTest/kotlin/com/ghn/poker/feature/feed/presentation/FeedViewModelTest.kt
@@ -1,9 +1,5 @@
-@file:Suppress("ktlint:standard:no-empty-file")
-
 package com.ghn.poker.feature.feed.presentation
 
-// TODO: Re-enable once mokkery is updated for kotlin 2.3+ support
-/*
 import com.ghn.gizmodb.common.models.NewsCategory
 import com.ghn.poker.core.network.ApiResponse
 import com.ghn.poker.core.testing.BaseViewModelTest
@@ -187,4 +183,3 @@ class FeedViewModelTest : BaseViewModelTest() {
         )
     }
 }
-*/

--- a/feature/feature-tracker/build.gradle.kts
+++ b/feature/feature-tracker/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("gizmo.feature")
-//    alias(libs.plugins.mokkery)
+    alias(libs.plugins.mokkery)
 }
 
 android {
@@ -23,8 +23,8 @@ kotlin {
             implementation(project(":common"))
         }
         commonTest.dependencies {
-//            implementation(libs.mokkery.core)
-//            implementation(libs.mokkery.coroutines)
+            implementation(libs.mokkery.core)
+            implementation(libs.mokkery.coroutines)
         }
     }
 }

--- a/feature/feature-tracker/src/commonTest/kotlin/com/ghn/poker/feature/tracker/data/repository/SessionRepositoryImplTest.kt
+++ b/feature/feature-tracker/src/commonTest/kotlin/com/ghn/poker/feature/tracker/data/repository/SessionRepositoryImplTest.kt
@@ -1,9 +1,5 @@
-@file:Suppress("ktlint:standard:no-empty-file")
-
 package com.ghn.poker.feature.tracker.data.repository
 
-// TODO: Re-enable once mokkery is updated for kotlin 2.3+ support
-/*
 import com.ghn.gizmodb.common.models.GameType
 import com.ghn.gizmodb.common.models.SessionDTO
 import com.ghn.gizmodb.common.models.Venue
@@ -205,4 +201,3 @@ private class TestSessionRepository(
         }
     }
 }
-*/

--- a/feature/feature-tracker/src/commonTest/kotlin/com/ghn/poker/feature/tracker/domain/usecase/impl/SessionUseCaseImplTest.kt
+++ b/feature/feature-tracker/src/commonTest/kotlin/com/ghn/poker/feature/tracker/domain/usecase/impl/SessionUseCaseImplTest.kt
@@ -1,9 +1,5 @@
-@file:Suppress("ktlint:standard:no-empty-file")
-
 package com.ghn.poker.feature.tracker.domain.usecase.impl
 
-// TODO: Re-enable once mokkery is updated for kotlin 2.3+ support
-/*
 import com.ghn.gizmodb.common.models.GameType
 import com.ghn.gizmodb.common.models.Venue
 import com.ghn.poker.core.network.ApiResponse
@@ -117,4 +113,3 @@ class SessionUseCaseImplTest {
         verifySuspend { repository.getSessions() }
     }
 }
-*/

--- a/feature/feature-tracker/src/commonTest/kotlin/com/ghn/poker/feature/tracker/presentation/SessionListViewModelTest.kt
+++ b/feature/feature-tracker/src/commonTest/kotlin/com/ghn/poker/feature/tracker/presentation/SessionListViewModelTest.kt
@@ -1,9 +1,5 @@
-@file:Suppress("ktlint:standard:no-empty-file")
-
 package com.ghn.poker.feature.tracker.presentation
 
-// TODO: Re-enable once mokkery is updated for kotlin 2.3+ support
-/*
 import com.ghn.gizmodb.common.models.Venue
 import com.ghn.poker.core.network.ApiResponse
 import com.ghn.poker.core.testing.BaseViewModelTest
@@ -163,4 +159,3 @@ class SessionListViewModelTest : BaseViewModelTest() {
         )
     }
 }
-*/

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,12 +14,12 @@ scrapeIt = [
 ]
 
 [versions]
-kotlin = "2.3.0-RC2"
+kotlin = "2.3.0"
 
-agp = "8.13.1"
+agp = "8.13.2"
 
 compose = "1.10.0"
-compose-plugin = "1.10.0-rc01"
+compose-plugin = "1.10.0-rc02"
 
 android-minSdk = "26"
 android-compileSdk = "36"
@@ -37,19 +37,20 @@ kotlinxCoroutinesCore = "1.10.2"
 kotlinxSerializationJson = "1.9.0"
 multiplatformSettings = "1.3.0"
 navigation3 = "1.0.0-alpha06"
-lifecycleViewmodelNav3 = "2.10.0-alpha06"
+lifecycleViewmodelNav3 = "2.10.0-alpha07"
 sqldelightVersion = "2.2.1"
 
 # Test
-mokkery = "3.0.0"
+mokkery = "3.1.0"
 mockk = "1.14.7"
 kotest = "6.0.7"
 
 ktor = "3.3.3"
 
 # Server
+flyway = "11.19.0"
 jdbc_sqlite = "3.43.2.2"
-jooq = "3.20.9"
+jooq = "3.20.10"
 logbackVersion = "1.4.11"
 jetbrainsKotlinJvm = "1.9.0"
 rssparser = "6.1.1"
@@ -134,7 +135,7 @@ jooq-coroutines = { module = "org.jooq:jooq-kotlin-coroutines", version.ref = "j
 jooq-test = { module = "org.jooq:jooq-test", version.ref = "jooq" }
 jooq-test-kotlin = { module = "org.jooq:jooq-test-kotlin", version.ref = "jooq" }
 bouncyCastle = { module = "org.bouncycastle:bcprov-jdk15on", version = "1.70" }
-flyway-core = { module = "org.flywaydb:flyway-core", version = "11.18.0" }
+flyway-core = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
 jdbc-sqlite = { module = "org.xerial:sqlite-jdbc", version = "3.51.1.0" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 ktor-client-core-v203 = { module = "io.ktor:ktor-client-core", version = "2.0.3" }
@@ -155,12 +156,12 @@ mokkery-coroutines = { module = "dev.mokkery:mokkery-coroutines", version.ref = 
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-flyway = { id = "org.flywaydb.flyway", version = "11.18.0" }
+flyway = { id = "org.flywaydb.flyway", version.ref = "flyway" }
 jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "compose-plugin" }
 jetbrainsKotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 jooq = { id = "nu.studer.jooq", version = "10.1.1" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
-kover = { id = "org.jetbrains.kotlinx.kover", version = "0.9.3" }
+kover = { id = "org.jetbrains.kotlinx.kover", version = "0.9.4" }
 ksp = { id = "com.google.devtools.ksp", version = "2.3.3" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "12.0.2" }
 mokkery = { id = "dev.mokkery", version.ref = "mokkery" }


### PR DESCRIPTION
  - Kotlin 2.3.0-RC2 → 2.3.0
  - AGP 8.13.1 → 8.13.2
  - Compose Plugin 1.10.0-rc01 → 1.10.0-rc02
  - Mokkery 3.0.0 → 3.1.0 (now compatible with Kotlin 2.3.0)